### PR TITLE
Fix/children not visible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ lerna-debug.log*
 .DS_Store
 Thumbs.db
 .idea/
-.vscode/*
 !.vscode/extensions.json
 *.swp
 *.swo

--- a/.gitignore
+++ b/.gitignore
@@ -82,10 +82,6 @@ db/specs.sqlite
 specs-data.json
 activity-data.json
 
-# Screenshots
-screenshot_*.png
-*.png
-
 # Database files
 *.sqlite
 *.sqlite3

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to NestJS",
+      "port": 9229,
+      "restart": true,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,39 @@
+{
+  "workbench.colorTheme": "Visual Studio Dark",
+  "editor.tabSize": 2,
+  "editor.fontFamily": "'CascaydiaCove Nerd Font Mono', Cascadia Code Nerd Font, Cascadia Code, D2Coding, Consolas, Fira Code, monospace",
+  "terminal.integrated.fontFamily": "Hack Nerd Font Mono, Cascadia Code, monospace",
+  "editor.fontLigatures": true,
+  "editor.minimap.enabled": false,
+  "files.exclude": {},
+  "vim.useSystemClipboard": true,
+  "terminal.integrated.copyOnSelection": true,
+  "terminal.integrated.defaultProfile.linux": "zsh",
+
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true, // 저장 시 자동 포맷
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "prettier.ignorePath": ".prettierignore",
+  "claudeWorkflow.specs.documentsPath": ".claude-workflow/specs",
+  "claudeWorkflow.specs.showHiddenFiles": false,
+  "claudeWorkflow.specs.autoRefresh": true,
+  "claudeWorkflow.specs.enableGitIntegration": true,
+  "claudeWorkflow.dependency.graphStyle": "obsidian",
+  "claudeWorkflow.dependency.nodeSize": 20,
+  "claudeWorkflow.dependency.edgeThickness": 2,
+  "claudeWorkflow.dependency.animationSpeed": 1000,
+  "claudeWorkflow.modelManager.preferences": {
+    "defaultModel": "claude-sonnet-4-20250514",
+    "taskSpecificModels": {},
+    "autoSwitching": false,
+    "persistScope": "workspace"
+  }
+}

--- a/scripts/sync-database.ts
+++ b/scripts/sync-database.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import * as fs from 'fs';
 
 async function syncDatabase() {
-  const specData = JSON.parse(fs.readFileSync('specs-data.json', 'utf-8'));
+  const specData = JSON.parse(fs.readFileSync('./specs-data.json', 'utf-8'));
   
   // Get API URL from environment or use localhost for development
   const apiUrl = process.env.API_URL || 'http://localhost:3001';


### PR DESCRIPTION
## Summary
- Fixed specification hierarchy not displaying children for features like `E01-F01`
- Resolved parent reference issues in the `batchSync()` endpoint
- Ensures data integrity when importing specifications from `specs-data.json`

## Technical Details
- Modified `backend/src/specs/specs.service.ts`:
  - Added `idToHierarchicalId` mapping to resolve short parent IDs to full hierarchical IDs
  - Updated parent resolution logic in `batchSync()` method
  - Handles both direct ID mapping and hierarchical ID construction
- Updated `scripts/sync-database.ts`:
  - Fixed file path to use relative path `./specs-data.json`

## Testing
1. Run `npx ts-node scripts/sync-database.ts` to sync specifications
2. Verify E01-F01 shows 6 children in the dashboard
3. Check database: `sqlite3 backend/db/specs.sqlite "SELECT hierarchical_id, parent FROM specs WHERE hierarchical_id LIKE
'E01-F01%'"`
4. Confirm API returns children: `curl http://localhost:3001/api/specs/tree`

## Breaking Changes
- None, backward compatible with existing data
